### PR TITLE
fix(zsh): initialize compinit before loading plugins

### DIFF
--- a/modules/home-manager/zsh.nix
+++ b/modules/home-manager/zsh.nix
@@ -23,7 +23,12 @@ in
       "rec" = "script -aq ~/term.log-$(date '+%Y%m%d-%H-%M')";
     };
 
-    initContent = lib.mkMerge [
+    initExtraFirst = ''
+      autoload -Uz compinit
+      compinit
+    '';
+
+    initExtra = lib.mkMerge [
       (lib.mkBefore ''
         skip_global_compinit=1
       '')


### PR DESCRIPTION
Fixes the 'compdef: command not found' error by initializing compinit in initExtraFirst, ensuring it's available when Antidote loads Oh My Zsh plugins. Also renames the invalid 'initContent' to 'initExtra'.