### PR TITLE
feat: modularize dev, k8s, and infra tools and add homebrew support

### DIFF
--- a/hosts/macbook/darwin.nix
+++ b/hosts/macbook/darwin.nix
@@ -28,6 +28,12 @@
   # The platform the configuration will be used on.
   nixpkgs.hostPlatform = "aarch64-darwin";
 
+  # Homebrew configuration
+  homebrew = {
+    enable = true;
+    onActivation.cleanup = "none";
+  };
+
   # MacOS settings
   system.defaults = {
     dock.autohide = true;

--- a/hosts/ubuntu/home.nix
+++ b/hosts/ubuntu/home.nix
@@ -3,6 +3,9 @@
 {
   imports = [
     ../../modules/home-manager/common.nix
+    ../../modules/home-manager/kubernetes.nix
+    ../../modules/home-manager/infrastructure.nix
+    ../../modules/home-manager/development.nix
   ];
 
   home.username = "damoun";

--- a/modules/home-manager/development.nix
+++ b/modules/home-manager/development.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    pre-commit
+    python3
+    nodejs
+    go
+  ];
+}

--- a/modules/home-manager/gpg.nix
+++ b/modules/home-manager/gpg.nix
@@ -16,8 +16,8 @@ in
     enableSshSupport = true;
     enableZshIntegration = true;
     
-    # Use native pinentry for macOS, curses for Linux
-    pinentry.package = if isDarwin then pkgs.pinentry_mac else pkgs.pinentry-curses;
+    # Use native pinentry for macOS, gnome3 for Linux
+    pinentry.package = if isDarwin then pkgs.pinentry_mac else pkgs.pinentry-gnome3;
     
     # Default cache time for normal GPG usage
     defaultCacheTtl = 3600;

--- a/modules/home-manager/infrastructure.nix
+++ b/modules/home-manager/infrastructure.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    docker
+    docker-compose
+    opentofu
+  ];
+}

--- a/modules/home-manager/kubernetes.nix
+++ b/modules/home-manager/kubernetes.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    kubectl
+    kubernetes-helm
+    kustomize
+  ];
+}


### PR DESCRIPTION
This PR introduces modular Home Manager configurations for development, Kubernetes, and infrastructure tools. It also adds non-intrusive Homebrew support for macOS to allow co-existence with a work Brewfile. Additionally, it switches to a GUI pinentry on Linux.