### PR TITLE
fix: resolve zsh deprecation warnings

### DIFF
--- a/modules/home-manager/zsh.nix
+++ b/modules/home-manager/zsh.nix
@@ -23,13 +23,10 @@ in
       "rec" = "script -aq ~/term.log-$(date '+%Y%m%d-%H-%M')";
     };
 
-    initExtraFirst = ''
-      autoload -Uz compinit
-      compinit
-    '';
-
-    initExtra = lib.mkMerge [
+    initContent = lib.mkMerge [
       (lib.mkBefore ''
+        autoload -Uz compinit
+        compinit
         skip_global_compinit=1
       '')
       ''


### PR DESCRIPTION
Migrates initExtraFirst and initExtra to initContent in zsh.nix as recommended by Home Manager to resolve evaluation warnings. Preserves the compinit performance optimization.