### PR TITLE
fix: define ZSH_CACHE_DIR for zsh plugins

### DIFF
--- a/modules/home-manager/zsh.nix
+++ b/modules/home-manager/zsh.nix
@@ -25,6 +25,9 @@ in
 
     initContent = lib.mkMerge [
       (lib.mkBefore ''
+        export ZSH_CACHE_DIR="$HOME/.cache/zsh"
+        mkdir -p "$ZSH_CACHE_DIR/completions"
+
         autoload -Uz compinit
         compinit
         skip_global_compinit=1
@@ -78,6 +81,7 @@ in
 
     sessionVariables = {
       EDITOR = "nvim";
+      ZSH_CACHE_DIR = "$HOME/.cache/zsh";
     };
 
     antidote = {


### PR DESCRIPTION
Defines ZSH_CACHE_DIR and ensures the completions directory exists. This fixes an error where the Oh My Zsh docker plugin attempted to write to root because the variable was undefined.