### PR TITLE
feat: implement terminal-first shell strategy

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./ghostty.nix
     ./gemini.nix
     ./git.nix
     ./zsh.nix

--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.ghostty
+  ];
+
+  home.file.".config/ghostty/config".text = ''
+    command = ${pkgs.tmux}/bin/tmux
+    theme = dark:Dracula,light:Dracula
+    font-size = 12
+  '';
+}

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -20,6 +20,8 @@
 
     extraConfig = ''
       set -g display-time 3000
+      set -g default-command "${pkgs.zsh}/bin/zsh"
+      set -g default-shell "${pkgs.zsh}/bin/zsh"
     '';
   };
 }


### PR DESCRIPTION
Configures Ghostty to launch Tmux by default, and Tmux to use the Nix-installed Zsh as the default shell and command. This allows using Zsh without needing to run chsh or modify system-wide shell policies.