### PR TITLE
fix: ghostty dock support and display fix

### DIFF
--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -50,7 +50,7 @@ in
     name = "Ghostty";
     genericName = "Terminal Emulator";
     exec = "${ghostty-launcher}/bin/ghostty-launcher";
-    icon = "com.mitchellh.ghostty";
+    icon = "${pkgs.ghostty}/share/icons/hicolor/512x512/apps/com.mitchellh.ghostty.png";
     terminal = false;
     categories = [ "System" "TerminalEmulator" ];
     comment = "Ghostty terminal via nixGL";

--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -1,20 +1,25 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
-  # This is the version that the user said worked for the UI.
-  ghostty-wrapped = pkgs.symlinkJoin {
-    name = "ghostty";
-    paths = [ pkgs.ghostty ];
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-    postBuild = ''
-      wrapProgram $out/bin/ghostty \
-        --set GSK_RENDERER gl
-    '';
-  };
+  isLinux = pkgs.stdenv.isLinux;
+
+  # Wrap ghostty on Linux to force the 'gl' renderer, fixing EGL display errors 
+  # common in GTK4 environments on some distributions.
+  ghostty-pkg = if isLinux then 
+    pkgs.symlinkJoin {
+      name = "ghostty";
+      paths = [ pkgs.ghostty ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/ghostty \
+          --set GSK_RENDERER gl
+      '';
+    }
+    else pkgs.ghostty;
 in
 {
   home.packages = [
-    ghostty-wrapped
+    ghostty-pkg
   ];
 
   home.file.".config/ghostty/config".text = ''

--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -1,8 +1,20 @@
 { pkgs, ... }:
 
+let
+  # This is the version that the user said worked for the UI.
+  ghostty-wrapped = pkgs.symlinkJoin {
+    name = "ghostty";
+    paths = [ pkgs.ghostty ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/ghostty \
+        --set GSK_RENDERER gl
+    '';
+  };
+in
 {
   home.packages = [
-    pkgs.ghostty
+    ghostty-wrapped
   ];
 
   home.file.".config/ghostty/config".text = ''

--- a/modules/home-manager/ghostty.nix
+++ b/modules/home-manager/ghostty.nix
@@ -16,10 +16,26 @@ let
       '';
     }
     else pkgs.ghostty;
+  # Create a dedicated launcher script for Ghostty on Linux to handle nixGL and environment.
+  ghostty-launcher = pkgs.writeShellScriptBin "ghostty-launcher" ''
+    # Source nix profiles to ensure 'nix' and other tools are in PATH
+    if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+      . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+    elif [ -e /nix/var/nix/profiles/default/etc/profile.d/nix.sh ]; then
+      . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+    fi
+
+    export NIXPKGS_ALLOW_UNFREE=1
+    export GSK_RENDERER=gl
+    
+    # Execute ghostty via nixGL
+    exec /nix/var/nix/profiles/default/bin/nix run --impure github:nix-community/nixGL#nixGLNvidia -- ghostty "$@"
+  '';
 in
 {
   home.packages = [
     ghostty-pkg
+    (lib.mkIf isLinux ghostty-launcher)
   ];
 
   home.file.".config/ghostty/config".text = ''
@@ -27,4 +43,19 @@ in
     theme = dark:Dracula,light:Dracula
     font-size = 12
   '';
+
+  # Enable XDG desktop entries to support launching from the Ubuntu dock
+  xdg.enable = true;
+  xdg.desktopEntries."com.mitchellh.ghostty" = lib.mkIf isLinux {
+    name = "Ghostty";
+    genericName = "Terminal Emulator";
+    exec = "${ghostty-launcher}/bin/ghostty-launcher";
+    icon = "com.mitchellh.ghostty";
+    terminal = false;
+    categories = [ "System" "TerminalEmulator" ];
+    comment = "Ghostty terminal via nixGL";
+    settings = {
+      StartupWMClass = "com.mitchellh.ghostty";
+    };
+  };
 }


### PR DESCRIPTION
Provides a robust fix for Ghostty on Ubuntu:
1. Wraps Ghostty with GSK_RENDERER=gl to fix OpenGL context errors.
2. Creates a dedicated launcher script that sources Nix profiles to ensure GUI launches correctly find the environment.
3. Overrides the XDG desktop entry to use the launcher script with nixGL, enabling seamless dock launching.
4. Correctly handles the absolute path to tmux in the Ghostty configuration.