### PR TITLE
feat: install proton pass-cli and set gh cli preference

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -56,11 +74,48 @@
         "type": "github"
       }
     },
+    "pass-cli": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778966277,
+        "narHash": "sha256-aNRSRLO75JQF0iZeol0lfGWmHLccJglVBNnJEdSXc/w=",
+        "owner": "damoun",
+        "repo": "pass-cli-flake",
+        "rev": "145c960008667b6cd9f74a6272f673c0b349b194",
+        "type": "github"
+      },
+      "original": {
+        "owner": "damoun",
+        "repo": "pass-cli-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pass-cli": "pass-cli"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,11 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    pass-cli = {
+      url = "github:damoun/pass-cli-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { self, nixpkgs, home-manager, nix-darwin, ... }@inputs: {

--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, inputs, ... }:
 
 {
   imports = [
@@ -17,6 +17,7 @@
     htop
     tldr
     gh
+    inputs.pass-cli.packages.${pkgs.system}.default
   ];
 
   # Let Home Manager install and manage itself.

--- a/modules/home-manager/gemini.nix
+++ b/modules/home-manager/gemini.nix
@@ -8,6 +8,9 @@
     - Commit often and in small, logical increments.
     - Never use `git add .`, `git add -A`, or similar commands. Always selectively add specific files.
     - Finalize changes by pushing the branch and opening a Pull Request.
+
+    ## Tooling Preferences
+    - Prefer using the GitHub CLI (`gh`) over `web_fetch` for interacting with GitHub (viewing logs, managing repositories, fetching alerts, etc.).
   '';
 
   home.file.".gemini/policies/shell-safety.toml".text = ''


### PR DESCRIPTION
This PR integrates the new pass-cli-flake into the dotfiles and sets the preferred tooling for GitHub interactions.

### Changes:
- Add pass-cli flake input and update flake.lock.
- Install pass-cli in the shared Home Manager configuration.
- Instructing Gemini to prefer using the GitHub CLI over web_fetch.