### PR TITLE
fix(zsh): silence dotDir deprecation warning

### DIFF
--- a/modules/home-manager/zsh.nix
+++ b/modules/home-manager/zsh.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   isDarwin = pkgs.stdenv.isDarwin;
@@ -7,6 +7,7 @@ in
 {
   programs.zsh = {
     enable = true;
+    dotDir = config.home.homeDirectory;
     enableCompletion = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;


### PR DESCRIPTION
Silences the Home Manager warning regarding the future default change of `programs.zsh.dotDir` by explicitly locking it to the home directory using an absolute path as recommended.